### PR TITLE
Fix in he.pt core test: doesn't fail on iPad anymore

### DIFF
--- a/Resources/tests/core.js
+++ b/Resources/tests/core.js
@@ -197,7 +197,7 @@
 			var osname = Ti.Platform.osname;
 			
 			var val = he.pt(2,3,1), worked = false;
-			if (osname == 'iphone' || (osname == 'android' && density == 'medium')) {
+			if (osname == 'iphone' || osname == 'ipad' || (osname == 'android' && density == 'medium')) {
 				worked = val==2;
 			}
 			else if (osname == 'android' && density == 'high') {


### PR DESCRIPTION
Hi,
   I did a REALLY small fix. The he.pt test in core tests was failing on iPad.

Not sure it is the way you would have done it, but here it is.

Thanks!

Jean-Philippe Boily
