### PR TITLE
Added he.test.assertTypeof and failure for async tests.

### DIFF
--- a/Resources/app.js
+++ b/Resources/app.js
@@ -2,7 +2,7 @@
 Titanium.UI.setBackgroundColor('#fff');
 
 //Load test configuration
-Ti.include('/tests/config.js');
+//Ti.include('/tests/config.js');
 
 //launch unit tests or demo
 var demo = (typeof(RUNDEMO)!='undefined') ? RUNDEMO : false;

--- a/Resources/helium.js
+++ b/Resources/helium.js
@@ -73,6 +73,20 @@ super simple unit testing framework
 			Ti.API.error('[Helium] UNIT TEST FAILED: '+description);
 		}
 	};
+	
+	//Assert that the passed value is of the correct type, does accept 'array' as a type and will use he.isArray to check arrays.
+	he.test.assertTypeof = function(/*Polymorphic*/ value, /*String*/ type, /*String*/ description) {
+		if (type === 'object' ||
+			type === 'number' ||
+			type === 'string' ||
+			type === 'undefined') {
+			return he.test.assert((typeof value === type), description);
+		} else if (type === 'array') {
+			return he.test.assert(he.isArray(value), description);
+		} else {
+			Ti.API.error('[Helium] invalid assertTypeof parameter passed, use: object, number, string or array');
+		}
+	};
 
 	//Run all tests, or the given suite
 	he.test.run = function(/*String [optional]*/ suite) {

--- a/Resources/helium.js
+++ b/Resources/helium.js
@@ -88,11 +88,13 @@ super simple unit testing framework
 		if (type === 'object' ||
 			type === 'number' ||
 			type === 'string' ||
+			type === 'boolean' ||
 			type === 'undefined') {
 			return he.test.assert((typeof value === type), description);
 		} else if (type === 'array') {
 			return he.test.assert(he.isArray(value), description);
 		} else {
+			he.test.assert(false, description);
 			Ti.API.error('[Helium] invalid assertTypeof parameter passed, use: object, number, string or array');
 		}
 	};

--- a/Resources/helium.js
+++ b/Resources/helium.js
@@ -30,7 +30,9 @@ super simple unit testing framework
 	successes = 0,
 	failures = 0,
 	warnings = 0,
-	executing = false;
+	executing = false,
+	asyncFailTimeout; // Holds a JS timeout object that will be exectued after a defined period if an async test is not completed.
+	
 	/*
 	Add a test to the unit test suite.  Possible arguments are:
 	{
@@ -52,7 +54,14 @@ super simple unit testing framework
 	};
 
 	//Flip a boolean flag to indicate a test has completed running
-	he.test.done = function() {executing=false;};
+	he.test.done = function() {
+		executing=false;
+		
+		// Test is done, if we have a failure timeout clear it, async test went ok.
+		if (asyncFailTimeout != undefined) {
+			clearTimeout(asyncFailTimeout);
+		}
+	};
 
 	//Insert a warning
 	he.test.warn = function(/*String*/ description) {
@@ -212,7 +221,26 @@ super simple unit testing framework
 
 					if (tst.unit != undefined) {
 						tst.unit.call(tst);
-						if (!tst.asynch) {executing = false;}
+						if (!tst.asynch) {
+							executing = false;
+						}
+						else {
+							// Async test has a fail message and timeout, check that he.test.done() has been called by callback after timeout time.
+							// This means that in async tests if the test is not completed within the timeout time (i.e. callback has not been fired) we mark the test as a failure.
+							if (tst.fail != undefined && tst.timeout != undefined) {
+								asyncFailTimeout = setTimeout(function () {
+									if (executing) { // It's still executing after specified timeout period.
+										// Give it a failure status.
+										failures++;
+										failureMessages.push(tst.fail);
+										Ti.API.error('[Helium] UNIT TEST FAILED: '+tst.fail);
+
+										// Manually mark the test as completed.
+										he.test.done();
+									}
+								}, tst.timeout);
+							}
+						}
 						testsExecuted++;
 					}
 					else { //assuming visual test in this case

--- a/Resources/helium.js
+++ b/Resources/helium.js
@@ -235,7 +235,7 @@ super simple unit testing framework
 										// Give it a failure status.
 										failures++;
 										failureMessages.push(tst.fail);
-										Ti.API.error('[Helium] UNIT TEST FAILED: '+tst.fail);
+										Ti.API.error('[Helium] UNIT TEST FAILED (after: '+tst.timeout+'): '+tst.fail);
 
 										// Manually mark the test as completed.
 										he.test.done();

--- a/Resources/tests/test.js
+++ b/Resources/tests/test.js
@@ -49,6 +49,7 @@
 			he.test.assertTypeof({}, 'object', 'Should be typeof object');
 			he.test.assertTypeof('foobar', 'string', 'Should be typeof string');
 			he.test.assertTypeof(123456, 'number', 'Should be typeof number');
+			he.test.assertTypeof(true, 'boolean', 'Should be typeof boolean');
 			
 			var blah;
 			he.test.assertTypeof(blah, 'undefined', 'Should be typeof undefined');

--- a/Resources/tests/test.js
+++ b/Resources/tests/test.js
@@ -30,4 +30,19 @@
 			]
 		}
 	});
+	
+	he.test.add({
+		name: 'Testing tyepof assert',
+		suite: 'test',
+		unit: function () {
+			he.test.assertTypeof({}, 'object', 'Should be typeof object');
+			he.test.assertTypeof('foobar', 'string', 'Should be typeof string');
+			he.test.assertTypeof(123456, 'number', 'Should be typeof number');
+			
+			var blah;
+			he.test.assertTypeof(blah, 'undefined', 'Should be typeof undefined');
+			
+			he.test.assertTypeof([], 'array', 'Should be typeof array');
+		}
+	});
 })();

--- a/Resources/tests/test.js
+++ b/Resources/tests/test.js
@@ -12,6 +12,17 @@
 	});
 	
 	he.test.add({
+		name: 'Test async failure after timeout',
+		suite: 'test',
+		asynch: true,
+		fail: 'Async test did fail as expected and error was logged after timeout.',
+		timeout: 500,
+		unit: function () {
+			// Don't call he.test.done() and we should get an error to signify the test did not complete withing the timeout (in this case 500ms).
+		}
+	});
+	
+	he.test.add({
 		name:'Testing visual test functionality',
 		suite:'test',
 		visual: {

--- a/docs/api.md
+++ b/docs/api.md
@@ -76,6 +76,24 @@ Add a unit test to the set of tests to be run.  `args` contains the necessary el
 		}
 	});
 	
+	//Asynchronous non-visual test with failure after specified timeout length
+	he.test.add({
+		name:'Test Ajax',
+		suite:'network',
+		asynch:true,
+		fail: "Message will be displayed if async test did not complete after specified timeout.",
+		timeout: 1000, //Add failure if he.test.done() has not called after 1000ms.
+		unit: function() {
+			var xhr = Ti.Network.createHTTPClient();
+			xhr.onload = function() {
+				he.test.assert(true,'Network call came back');
+				he.test.done();
+			};
+			xhr.open('GET','http://www.google.com');
+			xhr.send();
+		}
+	});
+	
 	//Visual test
 	he.test.add({
 		name:'Testing UI colors',

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,6 +155,30 @@ Make a test assertion, with a description of the condition you are testing.  Tes
 		}
 	});
 	
+### he.test.assertTypeof(/\*Polymorphic\*/ value, /\*String\*/ type, /\*String\*/ description)
+
+Asserts the value is of the passed type. Can pass 'array' as type and it will use he.isArray to test type.
+
+#### Example
+
+	he.test.add({
+		name: 'Test thing is object',
+		suite: 'things',
+		unit: function() {
+			var thing = {};
+			he.test.assertTypeof(thing, 'object', 'thing is object!')
+		}
+	})
+	
+	he.test.add({
+		name: 'Test foobar is array',
+		suite: 'things',
+		unit: function() {
+			var foobar = [];
+			he.test.assertTypeof(foobar, 'array', 'foobar is array!')
+		}
+	})
+	
 ### he.test.run(/\*String [optional]\*/ suite)
 
 Run unit tests, and print output to the console and screen (in the form of a summary alert).  Optionally takes a string, which will restrict the tests run to a given suite.  If suite is undefined or an empty string, all tests will be run.


### PR DESCRIPTION
added assertTypeof helper to he.test, can also accept 'array' as a type and will use he.isArray to test value. Internally uses he.assert for result of type check.

Added the ability to set a timeout and failure message for async tests that do not complete after a specified timeout. Doesn't break current async tests that do not specify a timeout and fail message with test object. Basically its optional to check after timeout value whether the test had completed or not.

Added tests for all changes and docs to API.md
